### PR TITLE
Fix realgud--ipdb-command-name

### DIFF
--- a/ipdb/core.el
+++ b/ipdb/core.el
@@ -175,7 +175,7 @@ Note that the script name path has been expanded via `expand-file-name'.
 
 (defun ipdb-suggest-invocation (debugger-name)
   "Suggest a ipdb command invocation via `realgud-suggest-invocaton'"
-  (realgud-suggest-invocation (or debugger-name realgud--ipdb-command-name)
+  (realgud-suggest-invocation (or realgud--ipdb-command-name debugger-name)
 			      realgud--ipdb-minibuffer-history
 			      "python" "\\.py"))
 


### PR DESCRIPTION
`or` returns first non nil value so if `realgud--ipdb-command-name` is at the start then it would be returned if it is not null.
otherwise, `debugger-name` is always returned even though `realgud--ipdb-command-name` is set
